### PR TITLE
Fix wrong mysql date format cause fatal error when MySQL in strict mode

### DIFF
--- a/system/app/Models/Mapper/ProductMapper.php
+++ b/system/app/Models/Mapper/ProductMapper.php
@@ -76,14 +76,14 @@ class Models_Mapper_ProductMapper extends Application_Model_Mappers_Abstract {
 		);
 
 		if ($model->getId()){
-			$data['updated_at'] = date(DATE_ATOM);
+			$data['updated_at'] = date(Tools_System_Tools::DATE_MYSQL);
 			$where = $this->getDbTable()->getAdapter()->quoteInto('id = ?', $model->getId());
 			$result = $this->getDbTable()->update($data, $where);
 			$model->registerObserver(new Tools_ProductWatchdog(array(
 				'action' => Tools_Cache_GarbageCollector::CLEAN_ONUPDATE
 			)));
 		} else {
-			$data['created_at'] = date(DATE_ATOM);
+			$data['created_at'] = date(Tools_System_Tools::DATE_MYSQL);
 			$id = $this->getDbTable()->insert($data);
 			if ($id){
 				$model->setId($id);


### PR DESCRIPTION
When mysql runs with 

```
@@sql_mode=NO_ENGINE_SUBSTITUTION
```

Save/update products via Models_Mapper_ProductMapper::getInstance()->save($product) cause 

```
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2014-08-08T12:57:58+03:00' for column 'updated_at' 
```

Fixed with use of proper format. :shipit: 
